### PR TITLE
Add list_lists tool to view available lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,9 @@ Tested on Windows with Claude Desktop, but should also work with Claude Code.
 - **Connect to AnyList:** Authenticate with your AnyList account and connect to a specific shopping list.
 - **Add Items:** Add new items to your shopping list with an optional quantity.
 - **Check Off Items:** Mark items as completed on your shopping list.
+- **List Items:** View all items on your shopping list, grouped by category.
+- **List Lists:** View all available lists in your account with unchecked item counts.
 - **Health Check:** A simple endpoint to verify that the server is running.
-
-
-### Next steps:
-- List items on shopping list
-- Delete items entirely from shopping list (not just check off)
 
 Note: The API to anylist comes from a fork of [this repo](https://github.com/codetheweb/anylist) by @codetheweb. The only change I made was to remove console.info statements, since the writing to stdout causes issues with local MCP servers.
 
@@ -79,12 +76,15 @@ Note: The API to anylist comes from a fork of [this repo](https://github.com/cod
 The following tools are registered with the MCP server:
 
 -   `health_check`: Check if the server is running.
--   `anylist_connect`: Test the connection to AnyList.
 -   `add_item`: Add an item to the shopping list.
     -   `name` (string, required): The name of the item to add.
     -   `quantity` (number, optional): The quantity of the item.
 -   `check_item`: Check off an item from the shopping list.
     -   `name` (string, required): The name of the item to check off.
+-   `list_items`: Get all items from the shopping list, grouped by category.
+    -   `include_checked` (boolean, optional): Include checked-off items (default: false).
+-   `list_lists`: Get all available lists in your AnyList account.
+    -   Returns each list name with its number of unchecked items.
 
 ## Testing
 

--- a/src/anylist-client.js
+++ b/src/anylist-client.js
@@ -63,6 +63,14 @@ class AnyListClient {
     return this.client.lists.map(list => list.name);
   }
 
+  getLists() {
+    if (!this.client || !this.client.lists) return [];
+    return this.client.lists.map(list => ({
+      name: list.name,
+      uncheckedCount: list.items ? list.items.filter(item => !item.checked).length : 0
+    }));
+  }
+
   // TODO: Update quantity
   async addItem(itemName, quantity = 1) {
     if (!this.targetList) {

--- a/src/server.js
+++ b/src/server.js
@@ -185,6 +185,51 @@ server.registerTool("list_items", {
   }
 });
 
+// Register list_lists tool
+server.registerTool("list_lists", {
+  title: "List Available Lists",
+  description: "Get all available lists in the AnyList account with the number of unchecked items in each list",
+  inputSchema: {}
+}, async () => {
+  try {
+    // Connect without a specific list to authenticate and fetch lists
+    await anylistClient.connect(process.env.ANYLIST_LIST_NAME || null);
+    const lists = anylistClient.getLists();
+
+    if (lists.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No lists found in the account.",
+          },
+        ],
+      };
+    }
+
+    const listOutput = lists.map(list => `- ${list.name} (${list.uncheckedCount} unchecked items)`).join("\n");
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Available lists (${lists.length}):\n${listOutput}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to list lists: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
## Summary
- Adds `getLists()` method to AnyListClient that returns list names and unchecked item counts
- Adds new `list_lists` MCP tool to expose available lists in the account
- Returns formatted output showing each list with its number of unchecked items
- Updates README documentation with new tool

## Test plan
- [x] Run the MCP server and verify `list_lists` tool appears in available tools
- [x] Call `list_lists` and verify it returns all available lists with unchecked item counts
- [x] Verify error handling when not authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)