### PR TITLE
Add recipe and meal planning support

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -238,6 +238,318 @@ server.registerTool("list_lists", {
   }
 });
 
+// Register list_recipes tool
+server.registerTool("list_recipes", {
+  title: "List Recipes",
+  description: "Get all recipes from the AnyList account with summary info",
+  inputSchema: {}
+}, async () => {
+  try {
+    const recipes = await anylistClient.getRecipes();
+
+    if (recipes.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No recipes found in the account.",
+          },
+        ],
+      };
+    }
+
+    const recipeList = recipes.map(r => {
+      const details = [];
+      if (r.rating) details.push(`rating: ${r.rating}/5`);
+      if (r.servings) details.push(`servings: ${r.servings}`);
+      if (r.prepTime) details.push(`prep: ${r.prepTime}min`);
+      if (r.cookTime) details.push(`cook: ${r.cookTime}min`);
+      const suffix = details.length > 0 ? ` (${details.join(', ')})` : '';
+      return `- ${r.name}${suffix}`;
+    }).join("\n");
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Recipes (${recipes.length}):\n${recipeList}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to list recipes: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Register get_recipe tool
+server.registerTool("get_recipe", {
+  title: "Get Recipe Details",
+  description: "Get full details of a recipe by name or identifier",
+  inputSchema: {
+    identifier: z.string().describe("Recipe name or UUID identifier")
+  }
+}, async ({ identifier }) => {
+  try {
+    const recipe = await anylistClient.getRecipe(identifier);
+
+    const lines = [`# ${recipe.name}`];
+    if (recipe.note) lines.push(`\n${recipe.note}`);
+
+    const meta = [];
+    if (recipe.rating) meta.push(`Rating: ${recipe.rating}/5`);
+    if (recipe.servings) meta.push(`Servings: ${recipe.servings}`);
+    if (recipe.prepTime) meta.push(`Prep time: ${recipe.prepTime} min`);
+    if (recipe.cookTime) meta.push(`Cook time: ${recipe.cookTime} min`);
+    if (recipe.sourceName) meta.push(`Source: ${recipe.sourceName}`);
+    if (recipe.sourceUrl) meta.push(`URL: ${recipe.sourceUrl}`);
+    if (recipe.nutritionalInfo) meta.push(`Nutrition: ${recipe.nutritionalInfo}`);
+    if (meta.length > 0) lines.push(`\n${meta.join('\n')}`);
+
+    if (recipe.ingredients.length > 0) {
+      lines.push('\n## Ingredients');
+      recipe.ingredients.forEach(ing => {
+        const text = ing.rawIngredient || [ing.quantity, ing.name].filter(Boolean).join(' ');
+        const note = ing.note ? ` (${ing.note})` : '';
+        lines.push(`- ${text}${note}`);
+      });
+    }
+
+    if (recipe.preparationSteps.length > 0) {
+      lines.push('\n## Steps');
+      recipe.preparationSteps.forEach((step, i) => {
+        lines.push(`${i + 1}. ${step}`);
+      });
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: lines.join('\n'),
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get recipe: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Register add_recipe tool
+server.registerTool("add_recipe", {
+  title: "Add Recipe",
+  description: "Add a new recipe to AnyList",
+  inputSchema: {
+    name: z.string().describe("Name of the recipe"),
+    note: z.string().optional().describe("Recipe description or notes"),
+    ingredients: z.array(z.object({
+      rawIngredient: z.string().optional().describe("Full ingredient text (e.g. '2 cups flour')"),
+      name: z.string().optional().describe("Ingredient name"),
+      quantity: z.string().optional().describe("Ingredient quantity"),
+      note: z.string().optional().describe("Ingredient note"),
+    })).optional().describe("List of ingredients"),
+    preparationSteps: z.array(z.string()).optional().describe("List of preparation steps"),
+    servings: z.string().optional().describe("Number of servings (e.g. '4 servings')"),
+    sourceName: z.string().optional().describe("Source name (e.g. cookbook or website name)"),
+    sourceUrl: z.string().optional().describe("Source URL"),
+    cookTime: z.number().optional().describe("Cook time in seconds"),
+    prepTime: z.number().optional().describe("Prep time in seconds"),
+    rating: z.number().min(0).max(5).optional().describe("Rating from 0-5"),
+    nutritionalInfo: z.string().optional().describe("Nutritional information"),
+    scaleFactor: z.number().optional().describe("Scale factor for the recipe"),
+  }
+}, async ({ name, note, ingredients, preparationSteps, servings, sourceName, sourceUrl, cookTime, prepTime, rating, nutritionalInfo, scaleFactor }) => {
+  try {
+    const result = await anylistClient.addRecipe({
+      name, note, ingredients, preparationSteps, servings,
+      sourceName, sourceUrl, cookTime, prepTime, rating,
+      nutritionalInfo, scaleFactor
+    });
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Successfully added recipe "${result.name}" (id: ${result.identifier})`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to add recipe: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Register get_calendar_events tool
+server.registerTool("get_calendar_events", {
+  title: "Get Meal Planning Calendar Events",
+  description: "Get meal planning calendar events, optionally filtered by date range. Defaults to past 30 days.",
+  inputSchema: {
+    start_date: z.string().optional().describe("Start date filter, ISO format YYYY-MM-DD (optional)"),
+    end_date: z.string().optional().describe("End date filter, ISO format YYYY-MM-DD (optional)"),
+    include_future: z.boolean().optional().describe("Include future events (default: false — past events only)"),
+  }
+}, async ({ start_date, end_date, include_future }) => {
+  try {
+    const events = await anylistClient.getCalendarEvents({
+      startDate: start_date,
+      endDate: end_date,
+      includeFuture: include_future,
+    });
+
+    if (events.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No meal planning calendar events found for the specified range.",
+          },
+        ],
+      };
+    }
+
+    const eventList = events.map(e =>
+      `${e.date} (${e.dayOfWeek}): ${e.title}`
+    ).join("\n");
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Meal planning calendar events (${events.length}):\n\n${eventList}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get calendar events: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Register schedule_meal tool
+server.registerTool("schedule_meal", {
+  title: "Schedule a Meal",
+  description: "Add a meal to the calendar for a specific date, linked to a recipe by name or UUID",
+  inputSchema: {
+    date: z.string().describe("Date in ISO format YYYY-MM-DD"),
+    recipe_identifier: z.string().describe("Recipe name or UUID to schedule"),
+  }
+}, async ({ date, recipe_identifier }) => {
+  try {
+    const result = await anylistClient.scheduleMeal(date, recipe_identifier);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Successfully scheduled "${result.recipeName}" on ${result.formatted}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to schedule meal: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Register schedule_note tool
+server.registerTool("schedule_note", {
+  title: "Schedule a Note on Calendar",
+  description: "Add a freeform (non-recipe) entry to the meal planning calendar, e.g. 'Scrounge' or 'Takeout'",
+  inputSchema: {
+    date: z.string().describe("Date in ISO format YYYY-MM-DD"),
+    title: z.string().describe("Freeform title for the calendar entry (e.g. 'Scrounge', 'Takeout')"),
+  }
+}, async ({ date, title }) => {
+  try {
+    const result = await anylistClient.scheduleNote(date, title);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Noted "${result.title}" on ${result.formatted}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to schedule note: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Register clear_calendar_range tool
+server.registerTool("clear_calendar_range", {
+  title: "Clear Calendar Range",
+  description: "Delete all meal planning calendar events within a date range. This is destructive and cannot be undone.",
+  inputSchema: {
+    start_date: z.string().describe("Start date of range to clear, ISO format YYYY-MM-DD"),
+    end_date: z.string().describe("End date of range to clear, ISO format YYYY-MM-DD"),
+  }
+}, async ({ start_date, end_date }) => {
+  try {
+    const result = await anylistClient.clearCalendarRange(start_date, end_date);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Cleared ${result.count} calendar event${result.count !== 1 ? 's' : ''} between ${result.startDate} and ${result.endDate}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to clear calendar range: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
## Summary

- Adds **7 new MCP tools** for recipes and meal planning calendar support
- Fixes a bug where `uid` was never set on the AnyList instance, causing recipe/calendar save operations to silently fail
- Includes 15 new unit tests covering the full workflow

### Recipe tools
- **list_recipes** — browse all recipes with summary info (rating, servings, cook/prep time)
- **get_recipe** — full recipe details by name or UUID, including ingredients and preparation steps
- **add_recipe** — create recipes with ingredients, steps, times, ratings, source info, etc.

### Meal planning calendar tools
- **get_calendar_events** — view calendar events with optional date range filter (defaults to past 30 days)
- **schedule_meal** — add a recipe-linked meal to the calendar by name or UUID
- **schedule_note** — add a freeform entry for non-recipe nights (e.g. "Takeout", "Scrounge")
- **clear_calendar_range** — remove all events in a date range

### Other changes
- `ensureAuthenticated()` helper extracted from `connect()`, so recipe/calendar tools don't need a shopping list name
- `uid` fix: the anylist-js library never populates `uid` on the AnyList instance, but it's needed in operation metadata for saves to actually persist — now extracted from list data after login

## Test plan
- [x] 33 unit tests passing (15 new + 18 existing)
- [x] Verified `get_calendar_events` returns real data
- [x] Verified `schedule_meal` creates a visible event in AnyList
- [x] Verified `add_recipe` creates a recipe that persists and is retrievable
- [x] Verified `clear_calendar_range` deletes events correctly
- [x] All test data cleaned up after each run

🤖 Generated with [Claude Code](https://claude.com/claude-code)