### PR TITLE
feat: add category support for add_item and list_categories tool

### DIFF
--- a/src/anylist-client.js
+++ b/src/anylist-client.js
@@ -96,8 +96,75 @@ class AnyListClient {
     }));
   }
 
+  /**
+   * Get available categories by inspecting existing items' categoryMatchId values.
+   * AnyList uses slug-based categoryMatchIds (e.g. 'dairy', 'produce', 'bakery').
+   */
+  getCategories() {
+    if (!this.targetList) return [];
+    const slugs = new Set();
+    for (const item of (this.targetList.items || [])) {
+      if (item._categoryMatchId) {
+        slugs.add(item._categoryMatchId);
+      }
+    }
+    return [...slugs].map(slug => this._slugToDisplayName(slug)).sort();
+  }
+
+  /**
+   * Convert a category slug to a display name.
+   * e.g. 'dairy' → 'Dairy', 'frozen-foods' → 'Frozen Foods'
+   */
+  _slugToDisplayName(slug) {
+    if (!slug) return 'Other';
+    return slug.split('-').map(word => {
+      if (['and', 'or', 'the', 'of'].includes(word)) return word;
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    }).join(' ');
+  }
+
+  /**
+   * Convert a display name to a category slug.
+   * e.g. 'Dairy' → 'dairy', 'Frozen Foods' → 'frozen-foods'
+   */
+  _displayNameToSlug(name) {
+    if (!name) return null;
+    return name.toLowerCase().replace(/\s+/g, '-');
+  }
+
+  /**
+   * Resolve a category name to its slug for categoryMatchId.
+   * Accepts display names ('Dairy'), slugs ('dairy'), or partial matches.
+   * Returns null if not found.
+   */
+  _resolveCategoryId(categoryName) {
+    if (!categoryName) return null;
+
+    const inputSlug = this._displayNameToSlug(categoryName);
+
+    // Get all known slugs from items
+    const knownSlugs = new Set();
+    for (const item of (this.targetList?.items || [])) {
+      if (item._categoryMatchId) {
+        knownSlugs.add(item._categoryMatchId);
+      }
+    }
+
+    // Exact match
+    if (knownSlugs.has(inputSlug)) return inputSlug;
+
+    // Try partial match (e.g. 'frozen' matches 'frozen-foods')
+    for (const slug of knownSlugs) {
+      if (slug.includes(inputSlug) || inputSlug.includes(slug)) return slug;
+    }
+
+    // If not found in existing items, still use the slug
+    // (AnyList may accept new category slugs)
+    return inputSlug;
+  }
+
   // TODO: Update quantity
-  async addItem(itemName, quantity = 1, notes = null) {
+  async addItem(itemName, quantity = 1, notes = null, category = null) {
     if (!this.targetList) {
       const error = new Error('Not connected to any list. Call connect() first.');
       console.error(error.message);
@@ -105,6 +172,13 @@ class AnyListClient {
     }
 
     try {
+      // Resolve category name to ID if provided
+      const categoryMatchId = this._resolveCategoryId(category);
+      if (category && !categoryMatchId) {
+        const available = this.getCategories();
+        throw new Error(`Unknown category "${category}". Available categories: ${available.join(', ')}`);
+      }
+
       // First, check if item already exists
       const existingItem = this.targetList.getItemByName(itemName);
 
@@ -117,6 +191,9 @@ class AnyListClient {
           if (notes !== null) {
             existingItem.details = notes;
           }
+          if (categoryMatchId) {
+            existingItem._categoryMatchId = categoryMatchId;
+          }
 
           console.error(`Unchecked existing item: ${existingItem.name}`);
           existingItem.save();
@@ -127,6 +204,9 @@ class AnyListClient {
           existingItem.quantity = quantity;
           if (notes !== null) {
             existingItem.details = notes;
+          }
+          if (categoryMatchId) {
+            existingItem._categoryMatchId = categoryMatchId;
           }
 
           existingItem.save();
@@ -139,6 +219,9 @@ class AnyListClient {
         }
 
         const newItem = this.client.createItem(itemOptions);
+        if (categoryMatchId) {
+          newItem._categoryMatchId = categoryMatchId;
+        }
         await this.targetList.addItem(newItem);
 
         // Set quantity and notes after adding (can't be done via _encode)
@@ -152,7 +235,7 @@ class AnyListClient {
           await newItem.save();
         }
 
-        console.error(`Added new item: ${newItem.name}`);
+        console.error(`Added new item: ${newItem.name}${category ? ` (${category})` : ''}`);
       }
 
     } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -59,22 +59,24 @@ server.registerTool("health_check", {
 // Register add_item tool
 server.registerTool("add_item", {
   title: "Add Item to Shopping List",
-  description: "Add an item to the AnyList shopping list with optional quantity and notes",
+  description: "Add an item to the AnyList shopping list with optional quantity, notes, and category",
   inputSchema: {
     name: z.string().describe("Name of the item to add"),
     quantity: z.number().min(1).optional().describe("Quantity of the item (optional, defaults to 1)"),
     notes: z.string().optional().describe("Notes to attach to the item (optional)"),
+    category: z.string().optional().describe("Category name for the item (e.g. 'Dairy', 'Produce'). Use list_categories tool to see available options."),
     list_name: z.string().optional().describe("Name of the list to use (defaults to ANYLIST_LIST_NAME env var)")
   }
-}, async ({ name, quantity, notes, list_name }) => {
+}, async ({ name, quantity, notes, category, list_name }) => {
   try {
     await anylistClient.connect(list_name);
-    await anylistClient.addItem(name, quantity || 1, notes || null);
+    await anylistClient.addItem(name, quantity || 1, notes || null, category || null);
+    const catSuffix = category ? ` in category "${category}"` : '';
     return {
       content: [
         {
           type: "text",
-          text: `Successfully added "${name}" to list "${anylistClient.targetList.name}"`,
+          text: `Successfully added "${name}" to list "${anylistClient.targetList.name}"${catSuffix}`,
         },
       ],
     };
@@ -86,6 +88,38 @@ server.registerTool("add_item", {
           text: `Failed to add item: ${error.message}`,
         },
       ],
+      isError: true,
+    };
+  }
+});
+
+// Register list_categories tool
+server.registerTool("list_categories", {
+  title: "List Shopping List Categories",
+  description: "Show available categories for a shopping list (e.g. Dairy, Produce, Bakery)",
+  inputSchema: {
+    list_name: z.string().optional().describe("Name of the list to use (defaults to ANYLIST_LIST_NAME env var)")
+  }
+}, async ({ list_name }) => {
+  try {
+    await anylistClient.connect(list_name);
+    const categories = anylistClient.getCategories();
+    if (categories.length === 0) {
+      return {
+        content: [{ type: "text", text: "No categories found." }],
+      };
+    }
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Available categories (${categories.length}):\n${categories.map(c => `- ${c}`).join('\n')}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [{ type: "text", text: `Failed to list categories: ${error.message}` }],
       isError: true,
     };
   }


### PR DESCRIPTION
## Summary

Adds category support when adding items to shopping lists, so items get properly categorized instead of landing in "Uncategorized".

### Changes (2 files)

#### `add_item` — new `category` parameter
- Accepts category display names (`Dairy`, `Frozen Foods`), slugs (`dairy`, `frozen-foods`), or partial matches (`frozen`)
- Sets `categoryMatchId` on new items and re-activated (unchecked) items

#### New `list_categories` tool
- Returns all available categories for a shopping list
- Categories derived from existing items' slug-based `categoryMatchId` values

### Implementation notes
- AnyList uses slug-based `categoryMatchId` values (e.g. `dairy`, `frozen-foods`) rather than UUIDs
- Category resolution: display name → slug conversion with exact, partial, and fallback matching
- Backwards compatible — `category` is optional, existing behavior unchanged without it

### Testing
```
# List available categories
list_categories → Bakery, Beverages, Dairy, Frozen Foods, Produce, etc.

# Add with category
add_item name="Butter" category="Dairy" → categorized correctly
```