### PR TITLE
doc: Make readme a bit more clear, add unofficial designation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# AnyList MCP Server
+# Unofficial AnyList MCP Server
 
 A local MCP server that integrates with [AnyList](https://www.anylist.com/) — shopping lists, recipes, meal planning, and more — exposed via the Model Context Protocol. Works with Claude Desktop, Claude Code, or any MCP-compatible client.
 
-## Architecture: Domain-Grouped Tools
-
-Instead of 18+ individual tools, this branch organizes functionality into **5 domain-grouped tools** with an `action` parameter. This reduces tool clutter while keeping full coverage:
+Instead of 18+ individual tools, functionality is organized into **5 domain-grouped tools**:
 
 | Tool | Actions | Description |
 |------|---------|-------------|
@@ -14,15 +12,21 @@ Instead of 18+ individual tools, this branch organizes functionality into **5 do
 | `meal_plan` | `list_events`, `list_labels`, `create_event`, `delete_event` | Meal planning calendar |
 | `recipe_collections` | `list`, `create` | Recipe organization |
 
-### Lazy Loading
+Right now there are known issues with creating recipies and recipe collections.
 
-- **`list` actions** return summaries (name, rating, times) — fast and lightweight
-- **`get` actions** return full details (ingredients, steps) — only when you need them
+# Installation: Claude Desktop
+The fastest way to get started is to download the latest `anylist-mcp.mcpb` from the release files. You can also build it following the instructions below.
 
-This two-step pattern keeps responses small and lets the model decide when to drill down.
+1. Open Claude Desktop -> Settings -> Extensions
+2. Drag and drop the `.mcpb` file, or click "Advanced settings" -> install extension
+3. Enter your configuration when prompted:
+   - **AnyList Email** — your AnyList account email
+   - **AnyList Password** — your AnyList account password
+   - **Default Shopping List** — optional, defaults to "Groceries"
+
+# Building from source/developing
 
 ## Prerequisites
-
 - [Node.js](https://nodejs.org/) v16+
 - An [AnyList](https://www.anylist.com/) account
 
@@ -173,15 +177,7 @@ npx @modelcontextprotocol/inspector node src/server.js
 
 This server can be packaged as an MCPB desktop extension for one-click installation in Claude Desktop and other MCP-compatible apps.
 
-### Install from .mcpb file
 
-1. Download or build the `.mcpb` file (see below)
-2. Open Claude Desktop → Settings → Extensions
-3. Drag and drop the `.mcpb` file, or click "Install from file"
-4. Enter your configuration when prompted:
-   - **AnyList Email** — your AnyList account email
-   - **AnyList Password** — your AnyList account password
-   - **Default Shopping List** — optional, defaults to "Groceries"
 
 ### Build the bundle
 
@@ -190,7 +186,7 @@ npm install
 npm run pack
 ```
 
-This produces an `anylist-mcp.mcpb` file you can distribute or install locally.
+This produces an `anylist-mcp.mcpb` file you can install locally.
 
 ## Contributions
 Contributions are welcome! Please feel free to submit issues and pull requests - especially if you find something off.


### PR DESCRIPTION
This pull request updates the `README.md` to clarify installation instructions, update project naming, and improve the onboarding experience for users, especially for Claude Desktop. It also removes outdated or redundant instructions and highlights known issues.

Project naming and context:

* Renamed the project from "AnyList MCP Server" to "Unofficial AnyList MCP Server" to clarify its status.

Installation and onboarding improvements:

* Added a new section with step-by-step instructions for installing the extension in Claude Desktop, including configuration details for AnyList account credentials and default shopping list.
* Removed the old, redundant ".mcpb file" installation instructions in favor of the new, clearer steps.
* Updated packaging instructions to clarify that the produced `.mcpb` file can be installed locally.

Project status and issues:

* Added a note about known issues with creating recipes and recipe collections to inform users of current limitations.

Documentation cleanup:

* Simplified the explanation of domain-grouped tools and removed the "lazy loading" section to streamline the documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R29)