### PR TITLE
feat: add bulk add_items action to shopping tool

### DIFF
--- a/src/tools/shopping.js
+++ b/src/tools/shopping.js
@@ -15,6 +15,7 @@ function buildDescription(stores) {
 - list_lists: Show all lists with item counts
 - list_items: Show items on a list (grouped by category)
 - add_item: Add an item to a list
+- add_items: Add several items to a list in one call (use this instead of repeating add_item)
 - check_item: Check off (complete) an item
 - delete_item: Permanently remove an item from a list
 - get_favorites: Get favorite items for a list
@@ -62,10 +63,20 @@ export function register(server, getClient) {
     title: "Shopping Lists & Items",
     description: buildDescription([]),
     inputSchema: {
-      action: z.enum(["list_lists", "list_items", "add_item", 
+      action: z.enum(["list_lists", "list_items", "add_item", "add_items",
         "set_item_store", "check_item", "delete_item", "get_favorites", "get_recents", "list_stores"]).describe("The shopping action to perform"),
       list_name: z.string().optional().describe("Name of the list (defaults to configured default list)"),
       name: z.string().optional().describe("Item name (required for add_item, set_item_store, check_item, delete_item)"),
+      items: z.array(z.union([
+        z.string(),
+        z.object({
+          name: z.string(),
+          quantity: z.number().min(1).optional(),
+          notes: z.string().optional(),
+          category: z.enum(valid_categories).optional(),
+          store_name: z.string().optional(),
+        })
+      ])).optional().describe("Items to add (add_items only). Each entry is either a plain item name or an object with name/quantity/notes/category/store_name"),
       quantity: z.number().min(1).optional().describe("Item quantity (add_item only, defaults to 1)"),
       notes: z.string().optional().describe("Notes for the item (add_item only)"),
       include_checked: z.boolean().optional().describe("Include checked-off items (list_items only, default false)"),
@@ -145,6 +156,31 @@ export function register(server, getClient) {
 
           await client.addItem(itemName, quantity || 1, notes || null, params.category || "other", params.store_name || null);
           return textResponse(`Successfully added "${itemName}" to list "${client.targetList.name}"`);
+        }
+        case "add_items": {
+          const entries = params.items;
+          if (!entries || entries.length === 0) throw new Error(`Action "add_items" requires a non-empty "items" array`);
+          await client.connect(list_name);
+          const added = [];
+          const failed = [];
+          for (const entry of entries) {
+            const item = typeof entry === "string" ? { name: entry } : entry;
+            try {
+              if (item.category && !valid_categories.includes(item.category)) {
+                throw new Error(`invalid category "${item.category}"`);
+              }
+              const { valid, message } = await validateStoreName(client, item.store_name);
+              if (!valid) throw new Error(message);
+              await client.addItem(item.name, item.quantity || 1, item.notes || null, item.category || "other", item.store_name || null);
+              added.push(item.name);
+            } catch (error) {
+              failed.push(`${item.name}: ${error.message}`);
+            }
+          }
+          const summary = [`Added ${added.length} of ${entries.length} items to list "${client.targetList.name}":`];
+          added.forEach(n => summary.push(`  ✓ ${n}`));
+          failed.forEach(f => summary.push(`  ✗ ${f}`));
+          return failed.length > 0 ? errorResponse(summary.join("\n")) : textResponse(summary.join("\n"));
         }
         case "check_item": {
           let itemName = name;

--- a/test/tools/shopping.test.js
+++ b/test/tools/shopping.test.js
@@ -49,6 +49,96 @@ describe('shopping tool', () => {
     });
   });
 
+  describe('add_items', () => {
+    it('adds multiple items from plain names', async () => {
+      const result = await handlers.shopping({ action: 'add_items', items: ['Milk', 'Eggs', 'Bread'] });
+      assert.ok(result.content[0].text.includes('Added 3 of 3 items'));
+      assert.equal(client._items.length, 3);
+      assert.deepEqual(client._items.map(i => i.name), ['Milk', 'Eggs', 'Bread']);
+    });
+
+    it('adds items with quantity, notes and category', async () => {
+      await handlers.shopping({
+        action: 'add_items',
+        items: [{ name: 'Eggs', quantity: 2, notes: 'organic', category: 'dairy' }],
+      });
+      assert.equal(client._items[0].quantity, 2);
+      assert.equal(client._items[0].notes, 'organic');
+      assert.equal(client._items[0].category, 'dairy');
+    });
+
+    it('defaults quantity to 1 and category to other', async () => {
+      await handlers.shopping({ action: 'add_items', items: ['Milk'] });
+      assert.equal(client._items[0].quantity, 1);
+      assert.equal(client._items[0].category, 'other');
+    });
+
+    it('mixes plain names and objects', async () => {
+      await handlers.shopping({ action: 'add_items', items: ['Milk', { name: 'Eggs', quantity: 12 }] });
+      assert.equal(client._items.length, 2);
+      assert.equal(client._items[1].quantity, 12);
+    });
+
+    it('continues past a failing item and reports it', async () => {
+      client.addItem = async (name) => {
+        if (name === 'Eggs') throw new Error('boom');
+        client._items.push({ name });
+      };
+      const result = await handlers.shopping({ action: 'add_items', items: ['Milk', 'Eggs', 'Bread'] });
+      const text = result.content[0].text;
+      assert.equal(result.isError, true);
+      assert.ok(text.includes('Added 2 of 3 items'));
+      assert.ok(text.includes('✓ Milk'));
+      assert.ok(text.includes('✗ Eggs: boom'));
+      assert.ok(text.includes('✓ Bread'));
+      assert.deepEqual(client._items.map(i => i.name), ['Milk', 'Bread']);
+    });
+
+    it('rejects an invalid category without aborting the batch', async () => {
+      const result = await handlers.shopping({
+        action: 'add_items',
+        items: [{ name: 'Soda', category: 'invalid-category' }, 'Milk'],
+      });
+      assert.equal(result.isError, true);
+      assert.ok(result.content[0].text.includes('invalid category "invalid-category"'));
+      assert.deepEqual(client._items.map(i => i.name), ['Milk']);
+    });
+
+    it('assigns a store to an item', async () => {
+      client._stores = [{ name: 'Costco' }];
+      await handlers.shopping({ action: 'add_items', items: [{ name: 'Milk', store_name: 'Costco' }] });
+      assert.equal(client._items[0].store, 'Costco');
+    });
+
+    it('rejects an unknown store without aborting the batch', async () => {
+      client._stores = [{ name: 'Costco' }];
+      const result = await handlers.shopping({
+        action: 'add_items',
+        items: [{ name: 'Milk', store_name: 'Nowhere' }, 'Eggs'],
+      });
+      assert.equal(result.isError, true);
+      assert.ok(result.content[0].text.includes('Store "Nowhere" not found'));
+      assert.deepEqual(client._items.map(i => i.name), ['Eggs']);
+    });
+
+    it('errors on a missing or empty items array', async () => {
+      const missing = await handlers.shopping({ action: 'add_items' });
+      assert.equal(missing.isError, true);
+      assert.ok(missing.content[0].text.includes('non-empty "items" array'));
+
+      const empty = await handlers.shopping({ action: 'add_items', items: [] });
+      assert.equal(empty.isError, true);
+    });
+
+    it('connects to the list only once for the whole batch', async () => {
+      let connects = 0;
+      const realConnect = client.connect.bind(client);
+      client.connect = async (n) => { connects++; return realConnect(n); };
+      await handlers.shopping({ action: 'add_items', items: ['Milk', 'Eggs', 'Bread'] });
+      assert.equal(connects, 1);
+    });
+  });
+
   describe('check_item', () => {
     it('checks off an existing item', async () => {
       client._items.push({ name: 'Milk', checked: false });


### PR DESCRIPTION
## What

Adds an `add_items` action to the `shopping` tool for adding several items to a list in one call.

Today, putting 13 items on a list means 13 `add_item` round trips, each re-entering the tool and re-running `client.connect()`. In practice, LLM clients handed a shopping list either give up partway or take a long time doing it. This collapses that into one call.

## How

- New `add_items` action plus an optional `items` array parameter.
- Entries are either a plain item name or an object with `name` / `quantity` / `notes` / `category` / `store_name`. The union is deliberate: a client handed a bare list of names can pass `["Milk", "Eggs"]` without knowing the object shape, which is the common case.
- `connect()` runs once for the whole batch rather than per item.
- Per-item failures are collected instead of aborting the batch. The response reports each item as `✓` or `✗ <name>: <reason>`, and only sets `isError` when something actually failed — so a partial success still tells the caller exactly what landed.
- Item creation reuses the existing `client.addItem()`, and store names go through the existing `validateStoreName()`, so dedupe / uncheck-existing / store-validation behavior is unchanged and consistent with `add_item`.

Note this is not a true batch API — AnyList still does one round trip per item. The win is one tool call instead of N, not raw throughput.

## Tests

10 new tests in `test/tools/shopping.test.js`, covering plain names, objects, mixed input, defaults, a mid-batch failure not aborting the rest, an invalid category not aborting the rest, per-item store assignment, an unknown store not aborting the rest, empty/missing array, and that `connect()` is called exactly once per batch.

Full suite: 69/69 passing on Node 22. `node --check` clean.

## Notes

- No changes to existing actions; `add_item` behaves exactly as before.
- Rebased onto current `main`, so this sits on top of the store-selection work from #35 and supports `store_name` per item.
- `params.items` is read directly rather than destructured at the top of the handler, to avoid shadowing the `const items` already declared inside the `list_items` case.
- Unrelated pre-existing observation, not addressed here: `quantity` doesn't appear to round-trip on newly created items (there's already a `// TODO: Update quantity` at `src/anylist-client.js`). `add_items` passes quantity through the same path as `add_item`, so it inherits that behavior rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
